### PR TITLE
Cirrus CI: Allow use of compute credits

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,7 @@
+# Allow compute credits usage for collaborators and anything pushed to the
+# main, staging, and trying branches. (So bors can use them.)
+use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' || $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'staging' || $CIRRUS_BRANCH == 'trying'
+
 Lint_task:
   container:
     image: python:3-slim


### PR DESCRIPTION
Limited to committers and Bors' `staging` and `trying` branches.