### PR TITLE
MemoryAmount: Add testsuite, fix exposed bugs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,3 +19,12 @@ Test_task:
     - poetry install --no-root
   script:
     - poetry run bork run test
+
+# Meta-task which depends on every other test/lint task to finish.
+success_task:
+  name: CI success
+  container: {image: "busybox"}
+  script: "exit 0"
+  depends_on:
+    - Lint
+    - Test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,3 +10,12 @@ Lint_task:
     - poetry install --no-root
   script:
     - poetry run bork run lint
+
+Test_task:
+  container:
+    image: python:3-slim
+  install_script:
+    - pip3 install poetry
+    - poetry install --no-root
+  script:
+    - poetry run bork run test

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,6 @@
 [flake8]
 select = C,E,F,I,N,W,B,B9
 max-line-length = 80
+
 import-order-style = smarkets
+application-import-names = memtree

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.direnv
 /dist
 __pycache__/
+/.hypothesis/

--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,2 @@
-status = ["Lint"]
+status = ["CI success"]
 delete_merged_branches = true

--- a/memtree/__init__.py
+++ b/memtree/__init__.py
@@ -19,11 +19,17 @@ class MemoryAmount(int):
     IEC_PREFIXES = ("", "ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi")
 
     def __str__(self):
-        if self == 0:
-            return "0 B"
-
         i = min(len(self.IEC_PREFIXES) - 1, (self.bit_length() - 1) // 10)
-        return f"{self / (1024**i):.0f} {self.IEC_PREFIXES[i]}B"
+        if i < 1:
+            return f"{int(self)} B"
+
+        j = 10 * i  # binary exponent for the unit we selected
+        round = self >> j  # integer part of the result
+        leftover = self & ((1 << j) - 1)  # number of leftover bytes
+        assert self == (round << j) + leftover
+
+        threshold = 1 << (j - 1)  # we round up above this many leftover bytes
+        return f"{round + int(leftover >= threshold)} {self.IEC_PREFIXES[i]}B"
 
 
 def tree(p: Path = _DEFAULT_NODE, *,

--- a/memtree/__init__.py
+++ b/memtree/__init__.py
@@ -19,7 +19,10 @@ class MemoryAmount(int):
     IEC_PREFIXES = ("", "ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi")
 
     def __str__(self):
-        i = min(len(self.IEC_PREFIXES), self.bit_length() // 10)
+        if self == 0:
+            return "0 B"
+
+        i = min(len(self.IEC_PREFIXES), (self.bit_length() - 1) // 10)
         return f"{self / (1024**i):.0f} {self.IEC_PREFIXES[i]}B"
 
 

--- a/memtree/__init__.py
+++ b/memtree/__init__.py
@@ -22,7 +22,7 @@ class MemoryAmount(int):
         if self == 0:
             return "0 B"
 
-        i = min(len(self.IEC_PREFIXES), (self.bit_length() - 1) // 10)
+        i = min(len(self.IEC_PREFIXES) - 1, (self.bit_length() - 1) // 10)
         return f"{self / (1024**i):.0f} {self.IEC_PREFIXES[i]}B"
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "attrs"
 version = "21.2.0"
 description = "Classes Without Boilerplate"
@@ -214,6 +222,34 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 pyreadline = {version = "*", markers = "sys_platform == \"win32\""}
 
 [[package]]
+name = "hypothesis"
+version = "6.13.5"
+description = "A library for property-based testing"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-resources (>=3.3.0)", "importlib-metadata (>=3.6)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
+cli = ["click (>=7.0)", "black (>=19.10b0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["pytz (>=2014.1)", "django (>=2.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=19.10b0)"]
+lark = ["lark-parser (>=0.6.5)"]
+numpy = ["numpy (>=1.9.0)"]
+pandas = ["pandas (>=0.25)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+zoneinfo = ["importlib-resources (>=3.3.0)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
+
+[[package]]
 name = "idna"
 version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -235,6 +271,14 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "jeepney"
@@ -317,6 +361,17 @@ python-versions = "*"
 testing = ["nose", "coverage"]
 
 [[package]]
+name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
 name = "psutil"
 version = "5.8.0"
 description = "Cross-platform lib for process and system monitoring in Python."
@@ -326,6 +381,14 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
 test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
+
+[[package]]
+name = "py"
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pycodestyle"
@@ -374,6 +437,27 @@ description = "A python implmementation of GNU readline."
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pytest"
+version = "6.2.4"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
 name = "pywin32-ctypes"
@@ -477,6 +561,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -551,9 +643,13 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "45aee021237096c86b84ed7dd2412a2649659afb501cbeacc9ce70d67a67938d"
+content-hash = "b9f888bcd032075cb775e1871a83301a83dc9829c8f054a6ead057cb70598386"
 
 [metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
@@ -683,6 +779,10 @@ humanfriendly = [
     {file = "humanfriendly-9.1-py2.py3-none-any.whl", hash = "sha256:d5c731705114b9ad673754f3317d9fa4c23212f36b29bdc4272a892eafc9bc72"},
     {file = "humanfriendly-9.1.tar.gz", hash = "sha256:066562956639ab21ff2676d1fda0b5987e985c534fc76700a19bd54bcb81121d"},
 ]
+hypothesis = [
+    {file = "hypothesis-6.13.5-py3-none-any.whl", hash = "sha256:7539bb747998dec16240fb273f2519f08e8ef576642d46feac02afa01ad14831"},
+    {file = "hypothesis-6.13.5.tar.gz", hash = "sha256:7b1d886ff78c6d2d3eee921d00116548e67310c2bf3bd13e3e59e073f4fdad88"},
+]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
@@ -690,6 +790,10 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-3.3.0-py3-none-any.whl", hash = "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"},
     {file = "importlib_metadata-3.3.0.tar.gz", hash = "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 jeepney = [
     {file = "jeepney-0.6.0-py3-none-any.whl", hash = "sha256:aec56c0eb1691a841795111e184e13cad504f7703b9a64f63020816afa79a8ae"},
@@ -718,6 +822,10 @@ pep8-naming = [
 pkginfo = [
     {file = "pkginfo-1.7.0-py2.py3-none-any.whl", hash = "sha256:9fdbea6495622e022cc72c2e5e1b735218e4ffb2a2a69cde2694a6c1f16afb75"},
     {file = "pkginfo-1.7.0.tar.gz", hash = "sha256:029a70cb45c6171c329dfc890cde0879f8c52d6f3922794796e06f577bb03db4"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 psutil = [
     {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
@@ -749,6 +857,10 @@ psutil = [
     {file = "psutil-5.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3"},
     {file = "psutil-5.8.0.tar.gz", hash = "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6"},
 ]
+py = [
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
@@ -773,6 +885,10 @@ pyreadline = [
     {file = "pyreadline-2.1.win-amd64.exe", hash = "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"},
     {file = "pyreadline-2.1.win32.exe", hash = "sha256:65540c21bfe14405a3a77e4c085ecfce88724743a4ead47c66b84defcf82c32e"},
     {file = "pyreadline-2.1.zip", hash = "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1"},
+]
+pytest = [
+    {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
+    {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
@@ -805,6 +921,10 @@ secretstorage = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,4 @@ hypothesis = "^6.13.5"
 
 [tool.bork.aliases]
 lint = "python -m flake8"
+test = "python -m pytest -v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ flake8-import-order = "^0.18.1"
 flake8-commas = "^2.0.0"
 flake8-bugbear = "^21.4.3"
 pep8-naming = "^0.11.1"
+pytest = "^6.2.4"
+hypothesis = "^6.13.5"
 
 [tool.bork.aliases]
 lint = "python -m flake8"

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -4,6 +4,10 @@ from hypothesis import given, note, strategies as st
 from memtree import MemoryAmount
 
 
+def test_zero():
+    assert str(MemoryAmount(0)) == '0 B'
+
+
 @pytest.mark.parametrize(
     "multiplier, prefix",
     ((1024 ** e, s) for (e, s) in enumerate(MemoryAmount.IEC_PREFIXES)),

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -1,0 +1,15 @@
+import pytest
+from hypothesis import given, note, strategies as st
+
+from memtree import MemoryAmount
+
+
+@pytest.mark.parametrize(
+    "multiplier, prefix",
+    ((1024 ** e, s) for (e, s) in enumerate(MemoryAmount.IEC_PREFIXES)),
+)
+@given(i=st.integers(1, 1023), f=st.floats(0, 1, exclude_max=True))
+def test_any_value(multiplier: int, prefix: str, i: int, f: float):
+    n = MemoryAmount(multiplier * i + int(f * multiplier))
+    note("n = {n!r} B")
+    assert str(n) == f"{i + 1 if f > 0.5 and multiplier > 1 else i} {prefix}B"

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -13,3 +13,13 @@ def test_any_value(multiplier: int, prefix: str, i: int, f: float):
     n = MemoryAmount(multiplier * i + int(f * multiplier))
     note("n = {n!r} B")
     assert str(n) == f"{i + 1 if f > 0.5 and multiplier > 1 else i} {prefix}B"
+
+
+MAX_PREFIX = MemoryAmount.IEC_PREFIXES[-1]
+MAX_MULTIPLIER = 1024 ** (len(MemoryAmount.IEC_PREFIXES) - 1)
+
+
+@given(i=st.integers(1), j=st.integers(0, MAX_MULTIPLIER - 1))
+def test_largest_values(i: int, j: int):
+    n = MemoryAmount(MAX_MULTIPLIER * i + j)
+    assert str(n) == f"{i if j < MAX_MULTIPLIER / 2 else i + 1} {MAX_PREFIX}B"

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -12,7 +12,7 @@ from memtree import MemoryAmount
 def test_any_value(multiplier: int, prefix: str, i: int, f: float):
     n = MemoryAmount(multiplier * i + int(f * multiplier))
     note("n = {n!r} B")
-    assert str(n) == f"{i + 1 if f > 0.5 and multiplier > 1 else i} {prefix}B"
+    assert str(n) == f"{i + 1 if f >= 0.5 and multiplier > 1 else i} {prefix}B"
 
 
 MAX_PREFIX = MemoryAmount.IEC_PREFIXES[-1]


### PR DESCRIPTION
- [x] Start adding property-based tests
  - One for values between 1 and 1024 of each unit
  - One for values above 1024 YiB

- [x] Fix 3 distincts bugs exposed by tests
  - “Off by 1/10th” in computing the unit  
    Values between 512 and 1024 would be wrongfully promoted to the next prefix.
  - An off-by-one in setting the max. unit caused an out-of-bounds access  
    Values 1024 YiB and above would attempt to use an inexistent, larger unit.
  - There were rounding issues when dividing silly-large numbers  
    Fixed by reimplementing the same functionality with integer arithmetic.

- [x] QA automation
  - CI: Run the testsuite in a new task
  - Bors: Wait on the new CI task  
    For future-proofing, it waits on a new “meta-task” that depends on all other CI tasks.
