### PR TITLE
package.nix: Filter `src` down to relevant files

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -55,7 +55,16 @@ rec {
 		propagatedBuildInputs = dependencies;
 		nativeCheckInputs = dev-dependencies;
 
-		src = ./.;
+		src = with lib.fileset;
+			toSource {
+				root = ./.;
+				fileset = unions [
+					./.flake8
+					./pyproject.toml
+					./memtree
+					./tests
+				];
+			};
 
 		checkPhase = ''
 			bork run lint


### PR DESCRIPTION
This avoids repeatedly rebuilding the package when nothing changed
in the Python source.
