### PR TITLE
shell.nix: Pass `pkgs` to ci.nix in case it was overriden

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ let
 in
 { pkgs ? import nixpkgs { }}:
 
-(import ./ci.nix {}).override (self: {
+(import ./ci.nix { inherit pkgs; }).override (self: {
 	nativeBuildInputs = with pkgs; self.nativeBuildInputs ++ [
 		pkgs.poetry
 	];


### PR DESCRIPTION
Bug introduced in 57a15a5e19b6797b8e3515292b10ed3eb6020398
