### PR TITLE
Demangle names for displaying

### DIFF
--- a/memtree/__init__.py
+++ b/memtree/__init__.py
@@ -31,8 +31,18 @@ class MemoryAmount(int):
         return f"{round + int(leftover >= threshold)} {self.IEC_PREFIXES[i]}B"
 
 
+def demangle_name(name: str) -> str:
+    if "." in name:
+        prefix, ext = name.rsplit(sep=".", maxsplit=1)
+        if ext in _STRIPPED_EXTS:
+            return prefix
+
+    return name
+
+
 def tree(p: Path = _DEFAULT_NODE, *,
-         color: Optional[Callable[[float], str]] = None) -> Tree:
+         color: Optional[Callable[[float], str]] = None,
+         demangle_name: Callable[[str], str] = demangle_name) -> Tree:
     if color is None:
         color = default_palette()
 
@@ -42,23 +52,15 @@ def tree(p: Path = _DEFAULT_NODE, *,
         except FileNotFoundError:
             return None
 
-    def name(q: Path) -> str:
-        if "." in q.name:
-            prefix, ext = q.name.rsplit(sep=".", maxsplit=1)
-            if ext in _STRIPPED_EXTS:
-                return prefix
-
-        return q.name
-
     def _tree(p: Path) -> Tree:
         m = mem(p)
         if m is None:
-            t = Tree(f"{name(p)}")
+            t = Tree(f"{demangle_name(p.name)}")
         elif not total_mem:
-            t = Tree(f"{name(p)}: {m}")
+            t = Tree(f"{demangle_name(p.name)}: {m}")
         else:
             t = Tree(
-                f"{name(p)}: {m} ({100 * m/total_mem :.0f}%)",
+                f"{demangle_name(p.name)}: {m} ({100 * m/total_mem :.0f}%)",
                 style=color(m / total_mem),
             )
 

--- a/memtree/__init__.py
+++ b/memtree/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import re
 from pathlib import Path
 from platform import system
 from typing import Callable, Optional
@@ -11,6 +12,7 @@ from .colors import default_palette
 assert system() == "Linux", f"{__name__} only works on Linux."
 
 _STRIPPED_EXTS = frozenset(("scope", "service", "slice"))
+_EXT_RE = re.compile(f".({'|'.join(_STRIPPED_EXTS)})$")
 _DEFAULT_NODE = Path("/sys/fs/cgroup/")
 
 
@@ -32,12 +34,7 @@ class MemoryAmount(int):
 
 
 def demangle_name(name: str) -> str:
-    if "." in name:
-        prefix, ext = name.rsplit(sep=".", maxsplit=1)
-        if ext in _STRIPPED_EXTS:
-            return prefix
-
-    return name
+    return _EXT_RE.sub('', name)
 
 
 def tree(p: Path = _DEFAULT_NODE, *,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ test = "python -m pytest -v"
 
 [tool.flake8]
 select = "C,E,F,I,N,W,B,B9"
+ignore = "E401"
 max-line-length = 80
 
 import-order-style = "smarkets"


### PR DESCRIPTION
- tree: Extract name-demangling function
- demangle_names: use compiled regexp instead of string manipulation
- flake8: allow multiple imports per line
- demangle_name: Unescape hex-encoded printable characters
