### PR TITLE
Speed-up CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,6 +9,7 @@ Lint_task: &task
     CACHIX_AUTH_TOKEN: "ENCRYPTED[80ed347b44a4127b859772f4455bea4085b4c245fcb0a21587ae322cb3bcb1705d2f95dc5580fa2ce60dd3550db7e7cb]"
   container:
     image: nixpkgs/cachix
+    use_in_memory_disk: true
   config_script:
     - cachix use "$CACHIX_CACHE_NAME"
   build_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,8 @@ Lint_task: &task
   container:
     image: nixpkgs/cachix
     use_in_memory_disk: true
+    cpu: 1
+    memory: 1G
   config_script:
     - cachix use "$CACHIX_CACHE_NAME"
   build_script:


### PR DESCRIPTION
- [x] Use a memory-backed working directory
- [ ] Replace Cachix.org with Cirrus' builtin HTTP-based cache
- [ ] Try greedy instances and parallelized testing?
  pytest-xdist seems to have too much overhead to amortize on our near-trivial tests
  Solution: write more tests?  :sweat_smile: 