### PR TITLE
Make Python module executable with `python -m`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,20 +27,9 @@ Test_task:
     - nix-shell --pure ci.nix --run 'bork run test'
 
 Integration_task:
-  nix_config_file:
-    path: /etc/nix/nix.conf
-    from_contents: >-
-      experimental-features = flakes nix-command
   <<: *task
-  build_script:
-    - nix build .
   script:
-    - nix run .
-  # Don't push to cache:
-  # - the build input currently depends on the whole repo's contents, so isn't cacheable;
-  # - it's somehow broken for the flake's build:
-  #   https://cirrus-ci.com/task/5650607323742208?logs=cache_update
-  cache_update_script: []
+    - nix-shell --pure ci.nix --run 'python -m memtree'
 
 
 # Meta-task which depends on every other test/lint task to finish.

--- a/memtree/__main__.py
+++ b/memtree/__main__.py
@@ -1,0 +1,5 @@
+import sys
+
+from . import cli
+
+sys.exit(cli.main())


### PR DESCRIPTION
- Make Python module executable with `python -m`
- CI: Run `memtree` in CI via `python -m`
