### PR TITLE
CI: flawlessly crunch on (corn)flakes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,12 @@ Integration_task:
 
 flake_task:
   name: Devour the Nix flake
+  # Incorrect in principle, as the build depends on memtree's source but it's
+  #  slow and highly-unlikely to fail without the integration task failing too
+  only_if: >
+    changesInclude('.cirrus.yml', '*.nix', 'flake.lock', 'pyproject.toml')
+    || $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH
+    || $CIRRUS_BRANCH =~ 'staging|trying'
   nix_config_file:
     path: /etc/nix/nix.conf
     from_contents: >-

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,6 +50,7 @@ success_task:
   container: {image: "busybox"}
   script: "exit 0"
   depends_on:
+    - Devour the Nix flake
     - Lint
     - Test
     - Integration

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,8 +46,10 @@ flake_task:
       experimental-features = flakes nix-command
   <<: *task
   build_script: []
-  script: nix run .#devour-self
-  cache_update_script: []
+  script: "nix run .#devour-self | tee result"
+  cache_update_script: >
+    [ -z "$CACHIX_AUTH_TOKEN" ] ||
+    cachix push "$CACHIX_CACHE_NAME" < ./result
 
 
 # Meta-task which depends on every other test/lint task to finish.


### PR DESCRIPTION
- [x] Make overall success depend on the flake being devoured
  Forgotten in #33 
- [x] Cache the flake's outputs
- [x] Only devour on the default branch and Bors', or if the flake's definition changed
  This is technically incorrect, as the flake could fail to build due to a change in the (Python) source, but it highly unlikely to happen without breaking the integration tests.
  On the flip side, this saves about a minute on CI for most PRs, and Bors will still check the flake builds... once I do set up my own Bors instance, I guess  😓
