### PR TITLE
ruff: Enable relevent rulesets, fix as needed

### DIFF
--- a/memtree/__init__.py
+++ b/memtree/__init__.py
@@ -22,7 +22,7 @@ _DEFAULT_NODE = Path("/sys/fs/cgroup/")
 class MemoryAmount(int):
     IEC_PREFIXES = ("", "ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi")
 
-    def __str__(self):
+    def __str__(self) -> str:
         i = min(len(self.IEC_PREFIXES) - 1, (self.bit_length() - 1) // 10)
         if i < 1:
             return f"{int(self)} B"
@@ -37,7 +37,7 @@ class MemoryAmount(int):
 
 
 def demangle_name(name: str) -> str:
-    def from_hex(m) -> str:
+    def from_hex(m: re.Match[str]) -> str:
         # Possibly inefficient, but lazy  ^^
         decoded = m[0].encode().decode("unicode_escape")
         if decoded in _PRINTABLE_NONSPACE:

--- a/memtree/__main__.py
+++ b/memtree/__main__.py
@@ -1,5 +1,3 @@
-import sys
-
 from . import cli
 
-sys.exit(cli.main())
+cli.main()

--- a/memtree/cli.py
+++ b/memtree/cli.py
@@ -3,7 +3,7 @@ from rich import print
 from . import tree
 
 
-def main():
+def main() -> None:
     print(tree())
 
 

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -4,15 +4,14 @@ from importlib import resources
 from typing import Any, Callable, Sequence, Tuple, TypeVar
 from warnings import warn
 
-
-T = TypeVar('T', str, Sequence[str])
+T = TypeVar("T", str, Sequence[str])
 Palette = Callable[[float], str]
 Vector = Tuple[float, float, float]
 
 
 @cache
 def turbo_data() -> Sequence[Vector]:
-    def vector(v: Any) -> Vector:
+    def vector(v: Any) -> Vector:  # noqa: ANN401
         if not isinstance(v, Sequence):
             raise TypeError("Expected a sequence", v)
         if not len(v) == 3:
@@ -55,7 +54,7 @@ def turbo(x: float) -> str:
         colormap[a][1] + (colormap[b][1] - colormap[a][1]) * f,
         colormap[a][2] + (colormap[b][2] - colormap[a][2]) * f,
     )
-    r, g, b = tuple(map(lambda y: int(255 * y), c))
+    r, g, b = tuple(int(255 * y) for y in c)
     return f"rgb({r},{g},{b})"
 
 

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -79,7 +79,7 @@ ansi_cyan = fixed_palette(
 def default_palette() -> Palette:
     from rich.console import ColorSystem, Console
 
-    match Console()._detect_color_system():
+    match Console().color_system:
         case ColorSystem.TRUECOLOR:
             return turbo
         case ColorSystem.STANDARD:

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -12,6 +12,7 @@ def turbo_data() -> Sequence[Tuple[float, float, float]]:
 
 
 T = TypeVar("T")
+Palette = Callable[[float], str]
 
 
 def clip(f: Callable[[float], T]) -> Callable[[float], T]:
@@ -47,7 +48,7 @@ def turbo(x: float) -> str:
     return f"rgb({r},{g},{b})"
 
 
-def fixed_palette(*p: Sequence[T]) -> Callable[[float], T]:
+def fixed_palette(*p: str) -> Palette:
     n = len(p)
     return clip(lambda x: p[min(n - 1, int(n * x))])
 
@@ -65,7 +66,7 @@ ansi_cyan = fixed_palette(
 )
 
 
-def default_palette():
+def default_palette() -> Palette:
     from rich.console import ColorSystem, Console
 
     cs = Console()._detect_color_system()

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -14,7 +14,7 @@ def turbo_data() -> Sequence[Vector]:
     def vector(v: Any) -> Vector:  # noqa: ANN401
         if not isinstance(v, Sequence):
             raise TypeError("Expected a sequence", v)
-        if not len(v) == 3:
+        if not len(v) == len(Vector.__args__):
             raise ValueError("Expected a 3-elements sequence")
         x, y, z = v
         if not all(isinstance(t, float) for t in (x, y, z)):

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -79,10 +79,10 @@ ansi_cyan = fixed_palette(
 def default_palette() -> Palette:
     from rich.console import ColorSystem, Console
 
-    cs = Console()._detect_color_system()
-    if cs == ColorSystem.TRUECOLOR:
-        return turbo
-    elif cs == ColorSystem.STANDARD:
-        return ansi_cyan
-    else:
-        return sixteen
+    match Console()._detect_color_system():
+        case ColorSystem.TRUECOLOR:
+            return turbo
+        case ColorSystem.STANDARD:
+            return ansi_cyan
+        case _:
+            return sixteen

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -1,18 +1,29 @@
 import json
 from functools import cache
 from importlib import resources
-from typing import Callable, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Sequence, Tuple, TypeVar
 from warnings import warn
 
 
-@cache
-def turbo_data() -> Sequence[Tuple[float, float, float]]:
-    with resources.files(__package__).joinpath("data/turbo.json").open() as f:
-        return tuple(map(tuple, json.load(f)))
-
-
-T = TypeVar("T")
+T = TypeVar('T', str, Sequence[str])
 Palette = Callable[[float], str]
+Vector = Tuple[float, float, float]
+
+
+@cache
+def turbo_data() -> Sequence[Vector]:
+    def vector(v: Any) -> Vector:
+        if not isinstance(v, Sequence):
+            raise TypeError("Expected a sequence", v)
+        if not len(v) == 3:
+            raise ValueError("Expected a 3-elements sequence")
+        x, y, z = v
+        if not all(isinstance(t, float) for t in (x, y, z)):
+            raise TypeError("Expected floats")
+        return (x, y, z)
+
+    with resources.files(__package__).joinpath("data/turbo.json").open() as f:
+        return tuple(vector(v) for v in json.load(f))
 
 
 def clip(f: Callable[[float], T]) -> Callable[[float], T]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ test = "python -m pytest -v"
 
 [tool.ruff]
 select = [
+       "RUF",                # ruff's own rules
        "E", "W", "F", "C90", # equivalent to flake8 (pycodestyle, pyflakes, mccabe)
        "ANN",                # require function annotations
        "ARG",                # unused arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ test = "python -m pytest -v"
 select = [
        "E", "W", "F", "C90", # equivalent to flake8 (pycodestyle, pyflakes, mccabe)
        "ANN",                # require function annotations
+       "ARG",                # unused arguments
        "B", "B9",            # bugbear
        "C4",                 # idiomatic style with comprehensions
        "COM",                # commas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ select = [
        "B", "B9",            # bugbear
        "C4",                 # idiomatic style with comprehensions
        "COM",                # commas
+       "ERA",                # remove commented-out code
        "I",                  # import order
        "N",                  # naming
        "PT",                 # pytest-specific rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "ISC"
 memtree = 'memtree.cli:main'
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 rich = "^13"
 
 
@@ -42,6 +42,7 @@ select = [
        "I",                  # import order
        "N",                  # naming
        "PT",                 # pytest-specific rules
+       "RET",                # control flow around `return`
        "UP",                 # pyupgrade: warn on obsolete syntax
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,18 @@ test = "python -m pytest -v"
 [tool.ruff]
 select = [
        "E", "W", "F", "C90", # equivalent to flake8 (pycodestyle, pyflakes, mccabe)
+       "ANN",                # require function annotations
        "B", "B9",            # bugbear
        "COM",                # commas
        "I",                  # import order
        "N",                  # naming
        "UP",                 # pyupgrade: warn on obsolete syntax
 ]
-ignore = [ "E401", "COM812" ]
+ignore = [
+       "ANN101", "ANN102",   # `self` and `cls` have implicit type annotations
+       "E401",               # allow multiple imports on one line
+       "COM812",             # incompatible with `ruff format`
+]
 line-length = 80
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ select = [
        "N",                  # naming
        "PT",                 # pytest-specific rules
        "RET",                # control flow around `return`
+       "SIM",                # simplification rules
        "SLF",                # don't poke around other classes' privates
        "UP",                 # pyupgrade: warn on obsolete syntax
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ select = [
        "E", "W", "F", "C90", # equivalent to flake8 (pycodestyle, pyflakes, mccabe)
        "ANN",                # require function annotations
        "B", "B9",            # bugbear
+       "C4",                 # idiomatic style with comprehensions
        "COM",                # commas
        "I",                  # import order
        "N",                  # naming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ select = [
        "PGH",                # misc. rules supplanting pygrep-hooks
        "PT",                 # pytest-specific rules
        "PTH",                # use pathlib, you philistine
+       "PL",                 # pylint
        "RET",                # control flow around `return`
        "SIM",                # simplification rules
        "SLF",                # don't poke around other classes' privates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ select = [
        "N",                  # naming
        "PT",                 # pytest-specific rules
        "RET",                # control flow around `return`
+       "SLF",                # don't poke around other classes' privates
        "UP",                 # pyupgrade: warn on obsolete syntax
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ select = [
        "I",                  # import order
        "N",                  # naming
        "PT",                 # pytest-specific rules
+       "PTH",                # use pathlib, you philistine
        "RET",                # control flow around `return`
        "SIM",                # simplification rules
        "SLF",                # don't poke around other classes' privates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ select = [
        "COM",                # commas
        "I",                  # import order
        "N",                  # naming
+       "PT",                 # pytest-specific rules
        "UP",                 # pyupgrade: warn on obsolete syntax
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ select = [
        "ERA",                # remove commented-out code
        "I",                  # import order
        "N",                  # naming
+       "PGH",                # misc. rules supplanting pygrep-hooks
        "PT",                 # pytest-specific rules
        "PTH",                # use pathlib, you philistine
        "RET",                # control flow around `return`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ select = [
        "COM",                # commas
        "I",                  # import order
        "N",                  # naming
+       "UP",                 # pyupgrade: warn on obsolete syntax
 ]
 ignore = [ "E401", "COM812" ]
 line-length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ select = [
        "ERA",                # remove commented-out code
        "I",                  # import order
        "N",                  # naming
+       "PERF",               # performance-related rules
        "PGH",                # misc. rules supplanting pygrep-hooks
        "PT",                 # pytest-specific rules
        "PTH",                # use pathlib, you philistine

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -21,7 +21,7 @@ def test_zero():
 def test_any_value(multiplier: int, prefix: str, i: int, f: float):
     n = MemoryAmount(multiplier * i + int(f * multiplier))
     note("n = {n!r} B")
-    assert str(n) == f"{i + 1 if f >= 0.5 and multiplier > 1 else i} {prefix}B"
+    assert str(n) == f"{i + 1 if f >= 1/2 and multiplier > 1 else i} {prefix}B"
 
 
 MAX_PREFIX = MemoryAmount.IEC_PREFIXES[-1]

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -8,6 +8,7 @@ from hypothesis import (
 from memtree import MemoryAmount
 
 
+# ruff: noqa: ANN201
 def test_zero():
     assert str(MemoryAmount(0)) == "0 B"
 

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -14,7 +14,7 @@ def test_zero():
 
 
 @pytest.mark.parametrize(
-    "multiplier, prefix",
+    ("multiplier", "prefix"),
     ((1024**e, s) for (e, s) in enumerate(MemoryAmount.IEC_PREFIXES)),
 )
 @given(i=st.integers(1, 1023), f=st.floats(0, 1, exclude_max=True))


### PR DESCRIPTION
- ruff: Enable pyupgrade rules
- Add missing type annotations
- memtree.colors.turbo_data: Validate during loading
- Fix (most) type errors
- ruff: enable comprehension rules
- ruff: Enable pytest-specific lints & fix issue
- ruff: Check control-flow conventions around `return`, fix as needed
- fixup! Fix (most) type errors
- ruff: Enable visibility rules
- ruff: Enable simplification rules
- ruff: Detect unused arguments
- ruff: Require use of pathlib
- ruff: Forbid commented-out code
- ruff: Enable pygrep-hook rules
- fixup! Fix (most) type errors
- ruff: Enable pylint rules
- ruff: Enable performance rules
- ruff: Enable own rules
