### PR TITLE
Fix outstanding lints

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
 				devShells = lib.mapAttrs (name: memtree: pkgs.mkShell {
 					nativeBuildInputs = [
 						pkgs.deadnix
+						pkgs.ruff
 						pkgs.yamllint
 						(memtree.interpreter.withPackages (pyPkgs: with pyPkgs; lib.optional (name == "default") [
 							ipython

--- a/memtree/__init__.py
+++ b/memtree/__init__.py
@@ -71,7 +71,7 @@ def tree(
             t = Tree(f"{demangle_name(p.name)}: {m}")
         else:
             t = Tree(
-                f"{demangle_name(p.name)}: {m} ({100 * m/total_mem :.0f}%)",
+                f"{demangle_name(p.name)}: {m} ({100 * m / total_mem:.0f}%)",
                 style=palette(m / total_mem),
             )
 

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -1,7 +1,8 @@
 import json
+from collections.abc import Sequence
 from functools import cache
 from importlib import resources
-from typing import Any, Callable, Sequence, Tuple, TypeVar
+from typing import Any, Callable, Tuple, TypeVar
 from warnings import warn
 
 T = TypeVar("T", str, Sequence[str])

--- a/memtree/colors.py
+++ b/memtree/colors.py
@@ -2,12 +2,12 @@ import json
 from collections.abc import Sequence
 from functools import cache
 from importlib import resources
-from typing import Any, Callable, Tuple, TypeVar
+from typing import Any, Callable, TypeVar
 from warnings import warn
 
 T = TypeVar("T", str, Sequence[str])
 Palette = Callable[[float], str]
-Vector = Tuple[float, float, float]
+Vector = tuple[float, float, float]
 
 
 @cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ name = "memtree"
 
 
 [tool.ruff]
+line-length = 80
+
+[tool.ruff.lint]
 select = [
        "ANN",     # require function annotations
        "ARG",     # unused arguments
@@ -66,11 +69,9 @@ select = [
        "UP",      # pyupgrade: warn on obsolete syntax
 ]
 ignore = [
-       "ANN101", "ANN102",   # `self` and `cls` have implicit type annotations
        "E401",               # allow multiple imports on one line
        "COM812",             # incompatible with `ruff format`
 ]
-line-length = 80
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -21,7 +21,9 @@ def test_zero():
 def test_any_value(multiplier: int, prefix: str, i: int, f: float):
     n = MemoryAmount(multiplier * i + int(f * multiplier))
     note("n = {n!r} B")
-    assert str(n) == f"{i + 1 if f >= 1/2 and multiplier > 1 else i} {prefix}B"
+    assert (
+        str(n) == f"{i + 1 if f >= 1 / 2 and multiplier > 1 else i} {prefix}B"
+    )
 
 
 MAX_PREFIX = MemoryAmount.IEC_PREFIXES[-1]


### PR DESCRIPTION
- `pyproject.toml` update `tools.ruff` for new version
- `flake`; include `ruff` in dev shells
- `colors.py`: replace deprecated types from `typing`:
  - `typing.Sequence` → `collections.abc.Sequence`
  - `typing.Tuple` → `tuple`
- apply `ruff format`
